### PR TITLE
[TEST] chat 서비스 채팅방/채팅리스트 조회 테스트코드 구현

### DIFF
--- a/apps/chat/src/chat/chat.controller.spec.ts
+++ b/apps/chat/src/chat/chat.controller.spec.ts
@@ -1,10 +1,10 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
+import { Types } from 'mongoose';
 import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
 import { ChatList } from './entities/chat-list.entity';
 import { ChatRoom } from './entities/chat-room.entity';
-import { Types } from 'mongoose';
 
 describe('ChatController', () => {
   const context = describe;

--- a/apps/chat/src/chat/chat.controller.spec.ts
+++ b/apps/chat/src/chat/chat.controller.spec.ts
@@ -65,57 +65,80 @@ describe('ChatController', () => {
     context('createChatRoom을 생성하면,', () => {
       it('success : 생성된 채팅방이 return 된다.', async () => {
         jest.spyOn(chatService, 'createChatRoom').mockResolvedValue(chatRoom);
+
         const result = await chatController.createChatRoom({ name: chatRoom.name });
+
         expect(result).toEqual(chatRoom);
         expect(chatService.createChatRoom).toHaveBeenCalledWith(chatRoom.name);
       });
       it('error : name이 undefined면 BadRequestException 에러가 발생한다.', async () => {
         mockError = new Error(BadRequestException.name);
         jest.spyOn(chatService, 'createChatRoom').mockRejectedValue(mockError);
+        
         await expect(chatController.createChatRoom({ name: undefined })).rejects.toThrow(mockError);
         expect(chatService.createChatRoom).rejects.toThrow(mockError);
       });
     });
 
     context('getChatRooms를 실행하면,', () => {
+      const userId = 1;
+
       it('success: 유저에게 해당되는 채팅방 목록을 반환한다.', async () => {
         jest.spyOn(chatService, 'getChatRooms').mockResolvedValue(chatRooms);
-        const result = await chatController.getChatRooms({ id: 1 });
+
+        const result = await chatController.getChatRooms({ id: userId });
+
         expect(result).toEqual(chatRooms);
-        expect(chatService.getChatRooms).toHaveBeenCalledWith(1);
+        expect(chatService.getChatRooms).toHaveBeenCalledWith(userId);
       });
 
-      it('error: 채팅방이 없을 경우 NotFoundException를 던진다.', async () => {
+      it('error: 채팅방이 없을 경우 NotFoundException을 반환한다.', async () => {
         jest.spyOn(chatService, 'getChatRooms').mockRejectedValue(new NotFoundException());
-        await expect(chatController.getChatRooms({ id: 1 })).rejects.toThrow(NotFoundException);
+
+        await expect(chatController.getChatRooms({ id: userId })).rejects.toThrow(
+          NotFoundException,
+        );
       });
     });
 
-    describe('getChatRoom을 실행하면,', () => {
+    context('getChatRoom을 실행하면,', () => {
+      const channelId = 1;
+
       it('success: 해당 채널의 채팅방을 반환한다.', async () => {
         jest.spyOn(chatService, 'getChatRoom').mockResolvedValue(chatRoom);
-        const result = await chatController.getChatRoom({ id: 1 });
+
+        const result = await chatController.getChatRoom({ id: channelId });
+
         expect(result).toEqual(chatRoom);
-        expect(chatService.getChatRoom).toHaveBeenCalledWith(1);
+        expect(chatService.getChatRoom).toHaveBeenCalledWith(channelId);
       });
 
-      it('error: 채팅방이 없을 경우 NotFoundException를 던진다.', async () => {
+      it('error: 채팅방이 없을 경우 NotFoundException을 반환한다.', async () => {
         jest.spyOn(chatService, 'getChatRoom').mockRejectedValue(new NotFoundException());
-        await expect(chatController.getChatRoom({ id: 1 })).rejects.toThrow(NotFoundException);
+
+        await expect(chatController.getChatRoom({ id: channelId })).rejects.toThrow(
+          NotFoundException,
+        );
       });
     });
 
-    describe('getChatList를 실행하면,', () => {
+    context('getChatList를 실행하면,', () => {
+      const channelId = 1;
+      const page = 1;
+
       it('success: 해당 채널의 채팅 리스트를 반환한다.', async () => {
         jest.spyOn(chatService, 'getChatList').mockResolvedValue(chatList);
-        const result = await chatController.getChatList({ id: 1, page: 1 });
+
+        const result = await chatController.getChatList({ id: channelId, page: page });
+
         expect(result).toEqual(chatList);
-        expect(chatService.getChatList).toHaveBeenCalledWith(1, 1);
+        expect(chatService.getChatList).toHaveBeenCalledWith(channelId, page);
       });
 
-      it('error: 채팅 리스트가 없을 경우 NotFoundException를 던진다.', async () => {
+      it('error: 채팅 리스트가 없을 경우 NotFoundException을 반환한다.', async () => {
         jest.spyOn(chatService, 'getChatList').mockRejectedValue(new NotFoundException());
-        await expect(chatController.getChatList({ id: 1, page: 1 })).rejects.toThrow(
+
+        await expect(chatController.getChatList({ id: channelId, page: page })).rejects.toThrow(
           NotFoundException,
         );
       });

--- a/apps/chat/src/chat/chat.controller.spec.ts
+++ b/apps/chat/src/chat/chat.controller.spec.ts
@@ -74,7 +74,7 @@ describe('ChatController', () => {
       it('error : name이 undefined면 BadRequestException 에러가 발생한다.', async () => {
         mockError = new Error(BadRequestException.name);
         jest.spyOn(chatService, 'createChatRoom').mockRejectedValue(mockError);
-        
+
         await expect(chatController.createChatRoom({ name: undefined })).rejects.toThrow(mockError);
         expect(chatService.createChatRoom).rejects.toThrow(mockError);
       });

--- a/apps/chat/src/chat/chat.controller.spec.ts
+++ b/apps/chat/src/chat/chat.controller.spec.ts
@@ -56,7 +56,7 @@ describe('ChatController', () => {
     jest.clearAllMocks();
   });
 
-  it('should be defined', () => {
+  it('Chat Controller, Service가 정의된다.', () => {
     expect(chatController).toBeDefined();
     expect(chatService).toBeDefined();
   });

--- a/apps/chat/src/chat/chat.controller.spec.ts
+++ b/apps/chat/src/chat/chat.controller.spec.ts
@@ -12,19 +12,19 @@ describe('ChatController', () => {
   let chatService: ChatService;
   let mockError: Error;
 
-  const chatRoom: ChatRoom = {
+  const chatRoom = {
     channel_id: 1,
     name: 'test',
     users: [],
     chat_lists: [],
   } as ChatRoom;
 
-  const chatRooms: ChatRoom[] = [
+  const chatRooms = [
     { channel_id: 1, name: 'test1', users: [], chat_lists: [] },
     { channel_id: 2, name: 'test2', users: [], chat_lists: [] },
   ] as ChatRoom[];
 
-  const chatList: ChatList = {
+  const chatList = {
     _id: new Types.ObjectId(),
     chat_list_id: 1,
     chats: [],

--- a/apps/chat/src/chat/chat.controller.spec.ts
+++ b/apps/chat/src/chat/chat.controller.spec.ts
@@ -2,7 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
-import { ChatRoom } from './entity/chat-room.entity';
+import { ChatRoom } from './entities/chat-room.entity';
 
 describe('ChatController', () => {
   const context = describe;

--- a/apps/chat/src/chat/chat.controller.spec.ts
+++ b/apps/chat/src/chat/chat.controller.spec.ts
@@ -1,36 +1,14 @@
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { Types } from 'mongoose';
+import { chatExamples } from '@shared/constants/mock-example';
 import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
-import { ChatList } from './entities/chat-list.entity';
-import { ChatRoom } from './entities/chat-room.entity';
 
 describe('ChatController', () => {
   const context = describe;
   let chatController: ChatController;
   let chatService: ChatService;
   let mockError: Error;
-
-  const chatRoom = {
-    channel_id: 1,
-    name: 'test',
-    users: [],
-    chat_lists: [],
-  } as ChatRoom;
-
-  const chatRooms = [
-    { channel_id: 1, name: 'test1', users: [], chat_lists: [] },
-    { channel_id: 2, name: 'test2', users: [], chat_lists: [] },
-  ] as ChatRoom[];
-
-  const chatList = {
-    _id: new Types.ObjectId(),
-    chat_list_id: 1,
-    chats: [],
-    created_at: new Date(),
-    updated_at: new Date(),
-  } as ChatList;
 
   beforeEach(async () => {
     const app: TestingModule = await Test.createTestingModule({
@@ -63,6 +41,8 @@ describe('ChatController', () => {
 
   describe('chat controller 테스트', () => {
     context('createChatRoom을 생성하면,', () => {
+      const chatRoom = chatExamples.newChatRoom;
+
       it('success : 생성된 채팅방이 return 된다.', async () => {
         jest.spyOn(chatService, 'createChatRoom').mockResolvedValue(chatRoom);
 
@@ -81,7 +61,10 @@ describe('ChatController', () => {
     });
 
     context('getChatRooms를 실행하면,', () => {
-      const userId = 1;
+      const userId = 101;
+      const chatRooms = chatExamples.chatRooms.filter((chatRoom) =>
+        chatRoom.users.includes(userId),
+      );
 
       it('success: 유저에게 해당되는 채팅방 목록을 반환한다.', async () => {
         jest.spyOn(chatService, 'getChatRooms').mockResolvedValue(chatRooms);
@@ -103,6 +86,7 @@ describe('ChatController', () => {
 
     context('getChatRoom을 실행하면,', () => {
       const channelId = 1;
+      const chatRoom = chatExamples.chatRooms.find((room) => room.channel_id === channelId);
 
       it('success: 해당 채널의 채팅방을 반환한다.', async () => {
         jest.spyOn(chatService, 'getChatRoom').mockResolvedValue(chatRoom);
@@ -125,6 +109,7 @@ describe('ChatController', () => {
     context('getChatList를 실행하면,', () => {
       const channelId = 1;
       const page = 1;
+      const chatList = chatExamples.chatLists.find((list) => list.chat_list_id === channelId);
 
       it('success: 해당 채널의 채팅 리스트를 반환한다.', async () => {
         jest.spyOn(chatService, 'getChatList').mockResolvedValue(chatList);

--- a/apps/chat/src/chat/chat.controller.ts
+++ b/apps/chat/src/chat/chat.controller.ts
@@ -1,13 +1,8 @@
-import {
-  GetChatListDto,
-  GetChatRoomDto,
-  GetChatRoomsDto,
-} from '@apps/api-gateway/src/chat/dto/req.dto';
 import { Controller } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
 import { MESSAGE } from '@shared/constants/message-pattern';
 import { ChatService } from './chat.service';
-import { CreateChatRoomDto } from './dto/req.dto';
+import { CreateChatRoomDto, GetChatListDto, GetChatRoomDto, GetChatRoomsDto } from './dto/req.dto';
 
 @Controller()
 export class ChatController {

--- a/apps/chat/src/chat/chat.service.spec.ts
+++ b/apps/chat/src/chat/chat.service.spec.ts
@@ -30,26 +30,26 @@ describe('ChatService', () => {
     exec: jest.fn(),
   };
 
-  const lastChatRoom: ChatRoom = {
+  const lastChatRoom = {
     channel_id: 1,
     name: 'last',
     users: [],
     chat_lists: [],
   } as ChatRoom;
 
-  const newChatRoom: ChatRoom = {
+  const newChatRoom = {
     channel_id: 2,
     name: 'test',
     users: [],
     chat_lists: [],
   } as ChatRoom;
 
-  const chatRooms: ChatRoom[] = [
-    { channel_id: 1, name: 'room1', users: [1], chat_lists: [] } as ChatRoom,
-    { channel_id: 2, name: 'room2', users: [1], chat_lists: [] } as ChatRoom,
-  ];
+  const chatRooms = [
+    { channel_id: 1, name: 'room1', users: [1], chat_lists: [] },
+    { channel_id: 2, name: 'room2', users: [1], chat_lists: [] },
+  ] as ChatRoom[];
 
-  const chatRoom: ChatRoom = {
+  const chatRoom = {
     channel_id: 1,
     name: 'room1',
     users: [],

--- a/apps/chat/src/chat/chat.service.spec.ts
+++ b/apps/chat/src/chat/chat.service.spec.ts
@@ -1,11 +1,11 @@
 import { InternalServerErrorException, NotFoundException } from '@nestjs/common';
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
+import { CHAT } from '@shared/constants/chat-constants';
 import mongoose, { Model } from 'mongoose';
 import { ChatService } from './chat.service';
-import { ChatRoom } from './entities/chat-room.entity';
 import { ChatList } from './entities/chat-list.entity';
-import { CHAT } from '@shared/constants/chat-constants';
+import { ChatRoom } from './entities/chat-room.entity';
 
 describe('ChatService', () => {
   const context = describe;

--- a/apps/chat/src/chat/chat.service.spec.ts
+++ b/apps/chat/src/chat/chat.service.spec.ts
@@ -2,7 +2,8 @@ import { InternalServerErrorException, NotFoundException } from '@nestjs/common'
 import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
 import { CHAT } from '@shared/constants/chat-constants';
-import mongoose, { Model } from 'mongoose';
+import { chatExamples } from '@shared/constants/mock-example';
+import { Model } from 'mongoose';
 import { ChatService } from './chat.service';
 import { ChatList } from './entities/chat-list.entity';
 import { ChatRoom } from './entities/chat-room.entity';
@@ -29,40 +30,6 @@ describe('ChatService', () => {
     limit: jest.fn().mockReturnThis(),
     exec: jest.fn(),
   };
-
-  const lastChatRoom = {
-    channel_id: 1,
-    name: 'last',
-    users: [],
-    chat_lists: [],
-  } as ChatRoom;
-
-  const newChatRoom = {
-    channel_id: 2,
-    name: 'test',
-    users: [],
-    chat_lists: [],
-  } as ChatRoom;
-
-  const chatRooms = [
-    { channel_id: 1, name: 'room1', users: [1], chat_lists: [] },
-    { channel_id: 2, name: 'room2', users: [1], chat_lists: [] },
-  ] as ChatRoom[];
-
-  const chatRoom = {
-    channel_id: 1,
-    name: 'room1',
-    users: [],
-    chat_lists: [],
-  } as ChatRoom;
-
-  const chatList: ChatList = {
-    _id: new mongoose.Types.ObjectId().toString(),
-    chat_list_id: 1,
-    chats: [],
-    created_at: new Date(),
-    updated_at: new Date(),
-  } as ChatList;
 
   const mockFindOneSortExec = (chatRoom: ChatRoom) => {
     mockChatRoomModel.findOne.mockReturnValueOnce({
@@ -119,6 +86,9 @@ describe('ChatService', () => {
 
   describe('chat service 테스트', () => {
     context('createChatRoom을 실행하면,', () => {
+      const lastChatRoom = chatExamples.lastChatRoom;
+      const newChatRoom = chatExamples.newChatRoom;
+
       it('success : Mogoose Model API가 호출된다.', async () => {
         mockFindOneSortExec(lastChatRoom);
         mockChatRoomModel.create.mockResolvedValue(newChatRoom);
@@ -158,7 +128,10 @@ describe('ChatService', () => {
     });
 
     context('getChatRooms를 실행하면,', () => {
-      const userId = 1;
+      const userId = 101;
+      const chatRooms = chatExamples.chatRooms.filter((chatRoom) =>
+        chatRoom.users.includes(userId),
+      );
 
       it('success: 사용자의 채팅방 목록을 반환한다.', async () => {
         mockFindExec(chatRooms);
@@ -179,6 +152,7 @@ describe('ChatService', () => {
 
     context('getChatRoom을 실행하면,', () => {
       const channelId = 1;
+      const chatRoom = chatExamples.chatRooms.find((room) => room.channel_id === channelId);
 
       it('success : 채널 ID에 맞는 채팅방을 반환한다.', async () => {
         mockFindOneExec(chatRoom);
@@ -200,6 +174,8 @@ describe('ChatService', () => {
     context('getChatList를 실행하면,', () => {
       const channelId = 1;
       const page = 1;
+      const chatRoom = chatExamples.chatRooms.find((room) => room.channel_id === channelId);
+      const chatList = chatExamples.chatLists.find((list) => list.chat_list_id === channelId);
 
       it('success : 채팅방과 채팅 리스트를 정상적으로 반환한다.', async () => {
         mockFindOneExec(chatRoom);

--- a/apps/chat/src/chat/chat.service.spec.ts
+++ b/apps/chat/src/chat/chat.service.spec.ts
@@ -44,16 +44,13 @@ describe('ChatService', () => {
     chat_lists: [],
   } as ChatRoom;
 
-  const userId = 1;
   const chatRooms: ChatRoom[] = [
-    { channel_id: 1, name: 'room1', users: [userId], chat_lists: [] } as ChatRoom,
-    { channel_id: 2, name: 'room2', users: [userId], chat_lists: [] } as ChatRoom,
+    { channel_id: 1, name: 'room1', users: [1], chat_lists: [] } as ChatRoom,
+    { channel_id: 2, name: 'room2', users: [1], chat_lists: [] } as ChatRoom,
   ];
 
-  const channelId = 1;
-  const page = 1;
   const chatRoom: ChatRoom = {
-    channel_id: channelId,
+    channel_id: 1,
     name: 'room1',
     users: [],
     chat_lists: [],
@@ -161,7 +158,9 @@ describe('ChatService', () => {
     });
 
     context('getChatRooms를 실행하면,', () => {
-      it('success: 사용자의 채팅방 목록이 반환된다.', async () => {
+      const userId = 1;
+
+      it('success: 사용자의 채팅방 목록을 반환한다.', async () => {
         mockFindExec(chatRooms);
 
         const result = await chatService.getChatRooms(userId);
@@ -170,7 +169,7 @@ describe('ChatService', () => {
         expect(mockChatRoomModel.find).toHaveBeenCalledWith({ users: userId });
       });
 
-      it('error : 사용자의 채팅방이 없으면 NotFoundException을 던진다.', async () => {
+      it('error : 사용자의 채팅방이 없으면 NotFoundException을 반환한다.', async () => {
         mockFindExec([]);
 
         await expect(chatService.getChatRooms(userId)).rejects.toThrow(NotFoundException);
@@ -179,7 +178,9 @@ describe('ChatService', () => {
     });
 
     context('getChatRoom을 실행하면,', () => {
-      it('success : 채널 ID에 맞는 채팅방이 반환된다.', async () => {
+      const channelId = 1;
+
+      it('success : 채널 ID에 맞는 채팅방을 반환한다.', async () => {
         mockFindOneExec(chatRoom);
 
         const result = await chatService.getChatRoom(channelId);
@@ -188,7 +189,7 @@ describe('ChatService', () => {
         expect(mockChatRoomModel.findOne).toHaveBeenCalledWith({ channel_id: channelId });
       });
 
-      it('error : 채널 ID로 채팅방을 찾을 수 없으면 NotFoundException을 던진다.', async () => {
+      it('error : 채널 ID로 채팅방을 찾을 수 없으면 NotFoundException을 반환한다.', async () => {
         mockFindOneExec(null);
 
         await expect(chatService.getChatRoom(channelId)).rejects.toThrow(NotFoundException);
@@ -197,7 +198,10 @@ describe('ChatService', () => {
     });
 
     context('getChatList를 실행하면,', () => {
-      it('success : 채팅방과 채팅 리스트가 정상적으로 반환된다.', async () => {
+      const channelId = 1;
+      const page = 1;
+
+      it('success : 채팅방과 채팅 리스트를 정상적으로 반환한다.', async () => {
         mockFindOneExec(chatRoom);
         mockFindChatListExec([chatList]);
 
@@ -206,21 +210,23 @@ describe('ChatService', () => {
         expect(result).toEqual(chatList);
         expect(mockChatRoomModel.findOne).toHaveBeenCalledWith({ channel_id: channelId });
         expect(mockChatListModel.find).toHaveBeenCalledWith({ _id: { $in: chatRoom.chat_lists } });
-        expect(mockChatListModel.sort).toHaveBeenCalledWith({ created_at: -1 });
+        expect(mockChatListModel.sort).toHaveBeenCalledWith({
+          created_at: CHAT.CHAT_LIST_SORT_DESC,
+        });
         expect(mockChatListModel.skip).toHaveBeenCalledWith(
           (page - 1) * CHAT.CHAT_LIST_PAGINATION_LIMIT,
         );
         expect(mockChatListModel.limit).toHaveBeenCalledWith(CHAT.CHAT_LIST_PAGINATION_LIMIT);
       });
 
-      it('error : 채팅방이 없으면 NotFoundException을 던진다.', async () => {
+      it('error : 채팅방이 없으면 NotFoundException을 반환한다.', async () => {
         mockFindOneExec(null);
 
         await expect(chatService.getChatList(channelId, page)).rejects.toThrow(NotFoundException);
         expect(mockChatRoomModel.findOne).toHaveBeenCalledWith({ channel_id: channelId });
       });
 
-      it('error : 채팅 리스트가 없으면 NotFoundException을 던진다.', async () => {
+      it('error : 채팅 리스트가 없으면 NotFoundException을 반환한다.', async () => {
         mockFindOneExec(chatRoom);
         mockFindChatListExec([]);
 

--- a/apps/chat/src/chat/chat.service.spec.ts
+++ b/apps/chat/src/chat/chat.service.spec.ts
@@ -3,7 +3,7 @@ import { getModelToken } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
 import { Model } from 'mongoose';
 import { ChatService } from './chat.service';
-import { ChatRoom } from './entity/chat-room.entity';
+import { ChatRoom } from './entities/chat-room.entity';
 
 describe('ChatService', () => {
   const context = describe;

--- a/apps/chat/src/chat/chat.service.spec.ts
+++ b/apps/chat/src/chat/chat.service.spec.ts
@@ -111,7 +111,7 @@ describe('ChatService', () => {
     jest.clearAllMocks();
   });
 
-  it('should be defined', () => {
+  it('Chat Service, Model이 정의된다.', () => {
     expect(chatService).toBeDefined();
     expect(chatRoomModel).toBeDefined();
     expect(chatListModel).toBeDefined();

--- a/apps/chat/src/chat/dto/req.dto.ts
+++ b/apps/chat/src/chat/dto/req.dto.ts
@@ -1,6 +1,29 @@
-import { IsString } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Min } from 'class-validator';
 
 export class CreateChatRoomDto {
   @IsString()
   public readonly name: string;
+}
+
+export class GetChatRoomsDto {
+  @Type(() => Number)
+  @IsInt()
+  public readonly id: number;
+}
+
+export class GetChatRoomDto {
+  @Type(() => Number)
+  @IsInt()
+  public readonly id: number;
+}
+
+export class GetChatListDto {
+  @IsInt()
+  public readonly id: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  public readonly page?: number = 1;
 }

--- a/shared/constants/mock-example.ts
+++ b/shared/constants/mock-example.ts
@@ -1,3 +1,7 @@
+import { ChatList } from '@apps/chat/src/chat/entities/chat-list.entity';
+import { ChatRoom } from '@apps/chat/src/chat/entities/chat-room.entity';
+import { Chat } from '@apps/chat/src/chat/entities/chat.entity';
+
 export const publicDataExamples = {
   postCategory: [
     {
@@ -45,4 +49,95 @@ export const publicDataExamples = {
     { career_category_id: 1, content: '0년차' },
     { career_category_id: 2, content: '1~3년차' },
   ],
+} as const;
+
+export const chatExamples = {
+  lastChatRoom: {
+    channel_id: 1,
+    name: 'last',
+    users: [],
+    chat_lists: [],
+  } as ChatRoom,
+
+  newChatRoom: {
+    channel_id: 2,
+    name: 'test',
+    users: [],
+    chat_lists: [],
+  } as ChatRoom,
+
+  chatRooms: [
+    {
+      channel_id: 1,
+      name: '101번과 102번의 채팅방',
+      users: [101, 102],
+      chat_lists: [
+        {
+          chat_list_id: 1,
+          chats: [
+            {
+              chat_id: 1,
+              sender_id: 101,
+              type: 'text',
+              content: '102번에게 보낸 메시지',
+              created_at: new Date(),
+            },
+            {
+              chat_id: 2,
+              sender_id: 102,
+              type: 'text',
+              content: '101번에게 보낸 메시지',
+              created_at: new Date(),
+            },
+          ],
+          created_at: new Date(),
+          updated_at: new Date(),
+        },
+      ],
+      last_chat: '101번에게 보낸 메시지',
+      created_at: new Date(),
+      updated_at: new Date(),
+    },
+  ] as ChatRoom[],
+
+  chatLists: [
+    {
+      chat_list_id: 1,
+      chats: [
+        {
+          chat_id: 1,
+          sender_id: 101,
+          type: 'text',
+          content: '102번에게 보낸 메시지',
+          created_at: new Date(),
+        },
+        {
+          chat_id: 2,
+          sender_id: 102,
+          type: 'text',
+          content: '101번에게 보낸 메시지',
+          created_at: new Date(),
+        },
+      ],
+      created_at: new Date(),
+      updated_at: new Date(),
+    },
+  ] as ChatList[],
+
+  chats: [
+    {
+      chat_id: 1,
+      sender_id: 101,
+      type: 'text',
+      content: '102번에게 보낸 메시지',
+      created_at: new Date(),
+    },
+    {
+      chat_id: 2,
+      sender_id: 102,
+      type: 'text',
+      content: '101번에게 보낸 메시지',
+      created_at: new Date(),
+    },
+  ] as Chat[],
 } as const;


### PR DESCRIPTION
## 반영 브랜치
- test/chat-service-get/40 -> dev

## 📌 작업내용
- [x] 채팅방 목록 조회 API 테스트코드 구현
- [x] 채팅방 조회 API 테스트코드 구현
- [x] 채팅리스트 조회 API 테스트코드 구현
- [x] 채팅 컨트롤러, 서비스 DTO 추가 및 경로 수정 

## 📸 상세한 설명 (사진은 선택)

### 주의❗️: 채팅 서비스 테스트를 위해서 해당 PR을 반드시 Pull 받는 것을 권장합니다
- 문제 : 기존에는 채팅 컨트롤러 및 서비스에서 `api-gateway`의 DTO를 사용했기 때문에 오류 발생
- 해결 : 채팅 마이크로서비스에 별도의 DTO 생성
- 해결 : 생성한 DTO로 채팅 컨트롤러, 서비스 DTO import 경로 수정

## ✨ PR Checklist
- [x] PR 제목 양식은 알맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [x] 이슈는 close 되었나요?
- [x] Reviewers, Labels 는 등록하였나요?
- [x] 불필요한 주석, 코드는 제거하였나요?

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
<!-- PR 후 코멘트로 받은 피드백에 대한 후속 작업 진행사항 -->

## ✅ 리뷰어 유의사항
<!-- 리뷰어들이 참고할 사항이 있다면 적어주세요 -->

closed #40 
