### PR TITLE
[FEAT] board 서비스 Exception Filter 적용

### DIFF
--- a/apps/api-gateway/src/board/board.service.ts
+++ b/apps/api-gateway/src/board/board.service.ts
@@ -8,24 +8,24 @@ export class BoardService {
   public constructor(@Inject('BOARD_SERVICE') private readonly boardClient: ClientProxy) {}
 
   public async getPostsByPostCategoryId(postCategoryId: number) {
-    return await this.boardClient.send(MESSAGE.POST_DATA.POST.GET_ALL_POST_BY_POST_CATEGORY_ID, {
+    return await this.boardClient.send(MESSAGE.POST.GET_ALL_POST_BY_POST_CATEGORY_ID, {
       postCategoryId,
     });
   }
 
   public async getPostById(id: number) {
-    return await this.boardClient.send(MESSAGE.POST_DATA.POST.GET_ONE_POST, { id });
+    return await this.boardClient.send(MESSAGE.POST.GET_ONE_POST, { id });
   }
 
   public async createPost(payload: { postCategoryId: number; createBoardDto: CreateBoardDto }) {
-    return await this.boardClient.send(MESSAGE.POST_DATA.POST.CREATE_POST, payload);
+    return await this.boardClient.send(MESSAGE.POST.CREATE_POST, payload);
   }
 
   public async updatePost(payload: { id: number; updateBoardDto: UpdateBoardDto }) {
-    return await this.boardClient.send(MESSAGE.POST_DATA.POST.UPDATE_POST, payload);
+    return await this.boardClient.send(MESSAGE.POST.UPDATE_POST, payload);
   }
 
   public async deletePost(id: number) {
-    return await this.boardClient.send(MESSAGE.POST_DATA.POST.DELETE_POST, { id });
+    return await this.boardClient.send(MESSAGE.POST.DELETE_POST, { id });
   }
 }

--- a/apps/board/src/board/board.controller.ts
+++ b/apps/board/src/board/board.controller.ts
@@ -1,26 +1,33 @@
-import { Controller } from '@nestjs/common';
+import { Controller, HttpStatus, UseInterceptors } from '@nestjs/common';
 import { MessagePattern, Payload } from '@nestjs/microservices';
+import { SetResponse } from '@shared/decorator/set-response.decorator';
+import { LoggingInterceptor } from '@shared/interceptor/message-logging.interceptor';
+import { TransformInterceptor } from '@shared/interceptor/transform.interceptor';
 import { MESSAGE } from 'shared/constants/message-pattern';
 import { BoardService } from './board.service';
 import { CreateBoardDto, UpdateBoardDto } from './dto/req.dto';
 
+@UseInterceptors(LoggingInterceptor, TransformInterceptor)
 @Controller()
 export class BoardController {
   public constructor(private readonly boardService: BoardService) {}
 
-  @MessagePattern(MESSAGE.POST_DATA.POST.GET_ALL_POST_BY_POST_CATEGORY_ID)
+  @SetResponse(MESSAGE.POST.GET_ALL_POST_BY_POST_CATEGORY_ID.cmd, HttpStatus.OK)
+  @MessagePattern(MESSAGE.POST.GET_ALL_POST_BY_POST_CATEGORY_ID)
   public async getPostsByPostCategoryId(@Payload() payload: { postCategoryId: number }) {
     const { postCategoryId } = payload;
     return this.boardService.getPostsByPostCategoryId(postCategoryId);
   }
 
-  @MessagePattern(MESSAGE.POST_DATA.POST.GET_ONE_POST)
+  @SetResponse(MESSAGE.POST.GET_ONE_POST.cmd, HttpStatus.OK)
+  @MessagePattern(MESSAGE.POST.GET_ONE_POST)
   public async getPostById(@Payload() payload: { id: number }) {
     const { id } = payload;
     return this.boardService.getPostById(id);
   }
 
-  @MessagePattern(MESSAGE.POST_DATA.POST.CREATE_POST)
+  @SetResponse(MESSAGE.POST.CREATE_POST.cmd, HttpStatus.CREATED)
+  @MessagePattern(MESSAGE.POST.CREATE_POST)
   public async createPost(
     @Payload() payload: { postCategoryId: number; createBoardDto: CreateBoardDto },
   ) {
@@ -28,13 +35,15 @@ export class BoardController {
     return this.boardService.createPost(postCategoryId, createBoardDto);
   }
 
-  @MessagePattern(MESSAGE.POST_DATA.POST.UPDATE_POST)
+  @SetResponse(MESSAGE.POST.UPDATE_POST.cmd, HttpStatus.OK)
+  @MessagePattern(MESSAGE.POST.UPDATE_POST)
   public async updatePost(@Payload() payload: { id: number; updateBoardDto: UpdateBoardDto }) {
     const { id, updateBoardDto } = payload;
     return this.boardService.updatePost(id, updateBoardDto);
   }
 
-  @MessagePattern(MESSAGE.POST_DATA.POST.DELETE_POST)
+  @SetResponse(MESSAGE.POST.DELETE_POST.cmd, HttpStatus.OK)
+  @MessagePattern(MESSAGE.POST.DELETE_POST)
   public async deletePost(@Payload() payload: { id: number }) {
     const { id } = payload;
     return this.boardService.deletePost(id);

--- a/apps/board/src/board/board.module.ts
+++ b/apps/board/src/board/board.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { ClientsModule, Transport } from '@nestjs/microservices';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import {
@@ -8,6 +8,7 @@ import {
   ProjectCategory,
   StackCategory,
 } from '@publicData/entities';
+import { LoggingInterceptor } from '@shared/interceptor/message-logging.interceptor';
 import { BoardController } from './board.controller';
 import { BoardService } from './board.service';
 import { Board } from './entities/board.entity';
@@ -35,6 +36,6 @@ import { Board } from './entities/board.entity';
   ],
   exports: [BoardService],
   controllers: [BoardController],
-  providers: [BoardService],
+  providers: [BoardService, LoggingInterceptor, Logger],
 })
 export class BoardModule {}

--- a/apps/board/src/board/board.service.ts
+++ b/apps/board/src/board/board.service.ts
@@ -1,6 +1,7 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CareerCategory, PositionCategory, PostCategory } from '@publicData/entities';
+import { CustomRpcException } from '@shared/filter/custom-rpc-exception';
 import { classToPlain } from 'class-transformer';
 import { Repository } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
@@ -37,7 +38,7 @@ export class BoardService {
     });
 
     if (posts.length === 0) {
-      throw new NotFoundException('게시글을 찾을 수 없습니다.');
+      throw new CustomRpcException(HttpStatus.NOT_FOUND, '게시글이 존재하지 않습니다.');
     }
 
     return posts.map((post) => classToPlain(post) as Board);
@@ -63,7 +64,7 @@ export class BoardService {
     });
 
     if (!post) {
-      throw new NotFoundException('게시글을 찾을 수 없습니다.');
+      throw new CustomRpcException(HttpStatus.NOT_FOUND, '게시글을 찾을 수 없습니다.');
     }
 
     return classToPlain(post) as Board;
@@ -107,7 +108,7 @@ export class BoardService {
     });
 
     if (!post) {
-      throw new NotFoundException('게시글을 찾을 수 없습니다.');
+      throw new CustomRpcException(HttpStatus.NOT_FOUND, '게시글을 찾을 수 없습니다.');
     }
 
     if (updateBoardDto.title) {
@@ -159,7 +160,7 @@ export class BoardService {
     });
 
     if (!post) {
-      throw new NotFoundException('게시글을 찾을 수 없습니다.');
+      throw new CustomRpcException(HttpStatus.NOT_FOUND, '게시글을 찾을 수 없습니다.');
     }
 
     await this.boardRepository.remove(post);

--- a/apps/board/src/main.ts
+++ b/apps/board/src/main.ts
@@ -1,11 +1,13 @@
 import { NestFactory } from '@nestjs/core';
 import { MicroserviceOptions, Transport } from '@nestjs/microservices';
+import { MicroRpcExceptionFilter } from '@shared/filter/rpc-exception.filter';
 import { initializeTransactionalContext } from 'typeorm-transactional';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   initializeTransactionalContext();
   const PORT = Number(process.env.BOARD_PORT);
+
   const app = await NestFactory.createMicroservice<MicroserviceOptions>(AppModule, {
     transport: Transport.TCP,
     options: {
@@ -14,7 +16,10 @@ async function bootstrap() {
     },
   });
 
+  app.useGlobalFilters(new MicroRpcExceptionFilter());
+
   await app.listen();
+
   console.info(`board-service Running On ${PORT} for TCP`);
 }
 bootstrap();

--- a/shared/constants/message-pattern.ts
+++ b/shared/constants/message-pattern.ts
@@ -26,14 +26,12 @@ export const MESSAGE = {
     },
   },
 
-  POST_DATA: {
-    POST: {
-      GET_ALL_POST_BY_POST_CATEGORY_ID: { cmd: 'get-all-post-by-post-category-id' },
-      GET_ONE_POST: { cmd: 'get-one-post' },
-      CREATE_POST: { cmd: 'create-post' },
-      UPDATE_POST: { cmd: 'update-post' },
-      DELETE_POST: { cmd: 'delete-post' },
-    },
+  POST: {
+    GET_ALL_POST_BY_POST_CATEGORY_ID: { cmd: 'get-all-post-by-post-category-id' },
+    GET_ONE_POST: { cmd: 'get-one-post' },
+    CREATE_POST: { cmd: 'create-post' },
+    UPDATE_POST: { cmd: 'update-post' },
+    DELETE_POST: { cmd: 'delete-post' },
   },
 
   CHAT: {


### PR DESCRIPTION
## 반영 브랜치
feat/board exception filter/38 -> `dev`

## 📌 작업내용
-  [x] **board service 에 exception filter를 적용**  
데이터가 존재하지 않을 때 NotFoundException을 반환하도록 처리했습니다. 

## 📸 상세한 설명 (사진은 선택)
- 정상 response data
<img src="https://github.com/user-attachments/assets/a98d26f9-dd70-4b91-9be2-c3de315badf7" width="500">

- 에러 response data
<img src="https://github.com/user-attachments/assets/ec547c9a-a758-44b9-9da5-fad493557a9e" width="500">


## ✨ PR Checklist
- [x] PR 제목 양식은 알맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요?
- [ ] 이슈는 close 되었나요?
- [x] Reviewers, Labels 는 등록하였나요?
- [x] 불필요한 주석, 코드는 제거하였나요?

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)
<!-- PR 후 코멘트로 받은 피드백에 대한 후속 작업 진행사항 -->

## ✅ 리뷰어 유의사항
<!-- 리뷰어들이 참고할 사항이 있다면 적어주세요 -->

closed #38 
